### PR TITLE
Backbone.Model compatibility/enhancement

### DIFF
--- a/lib/factory-lady.js
+++ b/lib/factory-lady.js
@@ -77,9 +77,14 @@
     }, function() {
       var doc = new model();
       var key;
+      var fn = Factory.setter;
       for(key in attrs) {
         if(attrs.hasOwnProperty(key)) {
-          doc[key] = attrs[key];
+          if(typeof doc[fn] === 'function') {
+            doc[fn](key, attrs[key]);
+          } else {
+            doc[key] = attrs[key];
+          }
         }
       }
       callback(doc);
@@ -105,8 +110,9 @@
   var assoc = function(name, attr) {
     return function(callback) {
       create(name, function(doc) {
+        var fn = Factory.getter;
         if(attr) {
-          callback(doc[attr]);
+          callback(doc[fn] ? doc[fn](attr) : doc[attr]);
         } else {
           callback(doc);
         }
@@ -119,6 +125,8 @@
   Factory.build  = build;
   Factory.create = create;
   Factory.assoc  = assoc;
+  Factory.setter = null;
+  Factory.getter = null;
 
   if(typeof module !== 'undefined' && module.exports) {
     module.exports = Factory;


### PR DESCRIPTION
Added feature for Factory models to specify 'setter' and 'getter' prior.

``` js
// Usage:
Factory.getter = 'get'; // Backbone.Model.prototype.get
Factory.setter = 'set'; // Backbone.Model.prototype.set
```
