### PR TITLE
Expose save and instantiate methods for easier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Factory 'post', (post) ->
   # same as Factory.create
 ```
 
+## Running tests:
+
+```npm i
+node ./node_modules/mocha/bin/mocha ./test
+```
+
 ## License
 
 Copyright (c) 2011 Peter Jihoon Kim. This software is licensed under the [MIT License](http://github.com/petejkim/factory-lady/raw/master/LICENSE).

--- a/lib/factory-lady.js
+++ b/lib/factory-lady.js
@@ -54,6 +54,16 @@
     };
   };
 
+  var instantiate = function(model, attrs) {
+    var key, doc = new model();
+    for(key in attrs) {
+      if(attrs.hasOwnProperty(key)) {
+        doc[key] = attrs[key];
+      }
+    }
+    return doc;
+  }
+
   var build = function(name, userAttrs, callback) {
     if(typeof userAttrs === 'function') {
       callback = userAttrs;
@@ -75,12 +85,15 @@
         cb();
       }
     }, function() {
-      var doc = new model();
-      var key;
-      for(key in attrs) {
-        if(attrs.hasOwnProperty(key)) {
-          doc[key] = attrs[key];
-        }
+      var doc = instantiate(model, attrs);
+      callback(doc);
+    });
+  };
+
+  var save = function(doc, callback) {
+    doc.save(function(err) {
+      if(err) {
+        throw err;
       }
       callback(doc);
     });
@@ -93,12 +106,7 @@
     }
 
     build(name, userAttrs, function(doc) {
-      doc.save(function(err) {
-        if(err) {
-          throw err;
-        }
-        callback(doc);
-      });
+      save(doc, callback);
     });
   };
 
@@ -119,6 +127,8 @@
   Factory.build  = build;
   Factory.create = create;
   Factory.assoc  = assoc;
+  Factory.save   = save;
+  Factory.instantiate = instantiate;
 
   if(typeof module !== 'undefined' && module.exports) {
     module.exports = Factory;
@@ -126,4 +136,3 @@
     this.Factory = Factory;
   }
 }());
-

--- a/lib/factory-lady.js
+++ b/lib/factory-lady.js
@@ -85,7 +85,7 @@
         cb();
       }
     }, function() {
-      var doc = instantiate(model, attrs);
+      var doc = Factory.instantiate(model, attrs);
       callback(doc);
     });
   };
@@ -106,7 +106,7 @@
     }
 
     build(name, userAttrs, function(doc) {
-      save(doc, callback);
+      Factory.save(doc, callback);
     });
   };
 


### PR DESCRIPTION
This branch exposes `Factory.save` and `Factory.instantiate`, which can be easily overridden if you are using a model library that doesn't use `new` and `.save(cb)`. Also updates the README with some spec details.
