### PR TITLE
Implemented dependent attribute (double handlebars)

### DIFF
--- a/lib/factory-lady.js
+++ b/lib/factory-lady.js
@@ -65,14 +65,36 @@
     hash.merge(attrs, userAttrs);
 
     asyncForEach(hash.keys(attrs), function(key, cb) {
+
+      var replace_templates = function(value, done){
+        if (typeof value === 'string' && value.match(/\{\{(.*?)\}\}/g)){
+          value.replace(/\{\{(.*?)\}\}/g, function(template){
+            var template_value = attrs[template.replace('{{', '').replace('}}','')];
+            if(typeof template_value === 'function') {
+              template_value(function(val) {
+                value = value.replace(template, val);
+              });
+            } else {
+              if (!template_value) template_value = '';
+              value = value.replace(template, template_value);
+            }
+          });
+        }
+        done(value);
+      };
       var fn = attrs[key];
       if(typeof fn === 'function') {
         fn(function(value) {
-          attrs[key] = value;
-          cb();
+          replace_templates(value, function(new_value){
+            attrs[key] = new_value;
+            cb();
+          });
         });
       } else {
-        cb();
+        replace_templates(attrs[key], function(new_value){
+          attrs[key] = new_value;
+          cb();
+        });
       }
     }, function() {
       var doc = new model();

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -28,11 +28,15 @@ describe('Factory', function() {
     , age: 25
     , job: Factory.assoc('job')
     , title: Factory.assoc('job', 'title')
+    , job_description: Factory.assoc('job', 'description')
+    , job_description_alternate: Factory.assoc('job', 'description_alternate')
     });
 
     Factory.define('job', Job, {
       title: 'Engineer'
-    , company: 'Foobar Inc.'
+    , company: function(cb) { cb('Foobar Inc.'); }
+    , description: function(cb) { cb('{{title}} in {{company}}'); }
+    , description_alternate: '{{title}}, {{company}}'
     });
   });
 
@@ -70,6 +74,52 @@ describe('Factory', function() {
             person.job.company.should.eql('Foobar Inc.');
             person.job.saveCalled.should.be.true;
             person.title.should.eql('Engineer');
+            done();
+          });
+        });
+      });
+
+      context('factory containing dependent attribute', function() {
+        it('is able to handle that where dependent attribute is a string', function(done){
+          Factory.build('person', function(person) {
+            (person instanceof Person).should.be.true;
+            (person.job instanceof Job).should.be.true;
+            person.should.not.have.property('saveCalled');
+            person.job.saveCalled.should.be.true;
+            person.job.title.should.eql('Engineer');
+            person.job.company.should.eql('Foobar Inc.');
+            person.job.description_alternate.should.eql('Engineer, Foobar Inc.');
+            person.job_description_alternate.should.eql('Engineer, Foobar Inc.');
+            done();
+          });
+        });
+
+        it('is able to handle that where dependent attribute is a function', function(done){
+          Factory.build('person', function(person) {
+            (person instanceof Person).should.be.true;
+            (person.job instanceof Job).should.be.true;
+            person.should.not.have.property('saveCalled');
+            person.job.saveCalled.should.be.true;
+            person.job.title.should.eql('Engineer');
+            person.job.company.should.eql('Foobar Inc.');
+            person.job.description.should.eql('Engineer in Foobar Inc.');
+            person.job_description.should.eql('Engineer in Foobar Inc.');
+            done();
+          });
+        });
+
+        it('is able to handle that where dependent attribute is passed as argument', function(done){
+          Factory.build('person', { name : 'John Doe, {{title}} - {{age}}' }, function(person) {
+            (person instanceof Person).should.be.true;
+            (person.job instanceof Job).should.be.true;
+            person.should.not.have.property('saveCalled');
+            person.job.saveCalled.should.be.true;
+            person.name.should.eql('John Doe, Engineer - 25');
+            person.title.should.eql('Engineer');
+            person.job.title.should.eql('Engineer');
+            person.job.company.should.eql('Foobar Inc.');
+            person.job.description.should.eql('Engineer in Foobar Inc.');
+            person.job_description.should.eql('Engineer in Foobar Inc.');
             done();
           });
         });


### PR DESCRIPTION
Implemented dependent attribute support.
- Supports both dependent attribute defined as a string or as lazy attribute.
- Dependent attribute may also contain associations.
- Dependent attribute can also be passed as arguments to #build and #create.
- Using double handlebars as template tags.

See: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#dependent-attributes

Definition example:

```
...
Factory.define('person', Person, {
      name: function(cb) { cb("person " + nameCounter++); }
    , age: 25
    , job: Factory.assoc('job')
    , title: Factory.assoc('job', 'title')
    , job_description: Factory.assoc('job', 'description')
    , job_description_alternate: Factory.assoc('job', 'description_alternate')
    });

Factory.define('job', Job, {
      title: 'Engineer'
    , company: function(cb) { cb('Foobar Inc.'); }
    , description: function(cb) { cb('{{title}} in {{company}}'); } 
        //--> "Engineer in Foobar Inc."
    , description_alternate: '{{title}}, {{company}}' 
        // --> "Engineer, Foobar Inc."
    });
```

Using it in factory#build example:

```
Factory.build( 'person',
    { name : 'John Doe, {{title}} - {{age}}'  },
    function(person) {
       ...
       // person.title = 'Engineer'; <-- Note: person.title was defined as an association
       // person.age = 25;
       // person.name = 'John Doe, Engineer - 25';
    }
);
```
