### PR TITLE
Allow sync(callbackless) lazy attributes

### DIFF
--- a/lib/factory-lady.js
+++ b/lib/factory-lady.js
@@ -67,10 +67,15 @@
     asyncForEach(hash.keys(attrs), function(key, cb) {
       var fn = attrs[key];
       if(typeof fn === 'function') {
-        fn(function(value) {
-          attrs[key] = value;
+        if (fn.length) {
+          fn(function(value) {
+            attrs[key] = value;
+            cb();
+          });
+        } else {
+          attrs[key] = fn();
           cb();
-        });
+        }
       } else {
         cb();
       }

--- a/test/factory-test.js
+++ b/test/factory-test.js
@@ -32,7 +32,7 @@ describe('Factory', function() {
 
     Factory.define('job', Job, {
       title: 'Engineer'
-    , company: 'Foobar Inc.'
+    , company: function() { return 'Foobar Inc.' }
     });
   });
 


### PR DESCRIPTION
It would be cool to allow callback-less functions as lazy attributes like this one:

``` javascript
Factory.define('person', Person, {
  name: function(){ return 'my name'; }
});
```

This is useful when using libraries such as [Faker](https://github.com/marak/Faker.js) to define dynamic factories like this:

``` javascript
Factory.define('person', Person, {
  name: Faker.Name.firstName,
  email: Faker.Internet.email
});
```

Thoughts? 
